### PR TITLE
Add environment selection to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,20 +17,35 @@ jobs:
     outputs:
       environment: ${{ steps.validate.outputs.environment }}
     steps:
-      - name: Ensure environment is allowed
+      - name: Ensure environment exists
         id: validate
         env:
           REQUESTED_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          case "$REQUESTED_ENVIRONMENT" in
-            flatwhite)
-              echo "environment=$REQUESTED_ENVIRONMENT" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "::error::Invalid environment '$REQUESTED_ENVIRONMENT'. Allowed environments: flatwhite"
-              exit 1
-              ;;
-          esac
+          if [ -z "$REQUESTED_ENVIRONMENT" ]; then
+            echo "::error::No environment provided. Choose an environment before running the workflow."
+            exit 1
+          fi
+
+          api_url="https://api.github.com/repos/$REPOSITORY/environments/$REQUESTED_ENVIRONMENT"
+          status=$(curl -sS \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -o "$RUNNER_TEMP/environment.json" \
+            -w '%{http_code}' \
+            "$api_url")
+
+          if [ "$status" -ne 200 ]; then
+            if [ -f "$RUNNER_TEMP/environment.json" ]; then
+              echo "::debug::$(cat "$RUNNER_TEMP/environment.json")"
+            fi
+            echo "::error::Environment '$REQUESTED_ENVIRONMENT' was not found in repository '$REPOSITORY'."
+            exit 1
+          fi
+
+          echo "environment=$REQUESTED_ENVIRONMENT" >> "$GITHUB_OUTPUT"
 
   deploy:
     name: Deploy to remote server


### PR DESCRIPTION
## Summary
- prompt for the deployment environment when manually triggering the workflow
- validate the requested environment before proceeding with the deploy job
- use the validated environment for environment-scoped secrets and variables during deployment

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_b_68ff2efd7fe0832286952701c4f8b771