### PR TITLE
Add client configuration summary to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,3 +127,78 @@ jobs:
         if: always()
         run: |
           rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub
+
+      - name: Display client connection details
+        if: success()
+        env:
+          XRAY_DOMAIN: ${{ vars.TARGET_DOMAIN_NAME }}
+          XRAY_UUID: ${{ secrets.UUID }}
+          XRAY_FLOW: xtls-rprx-vision
+          XRAY_PORT: ${{ vars.XRAY_INBOUND_PORT }}
+        run: |
+          set -eo pipefail
+
+          DOMAIN="${XRAY_DOMAIN}"
+          UUID="${XRAY_UUID}"
+          FLOW="${XRAY_FLOW}"
+          PORT="${XRAY_PORT:-}"
+
+          if [ -z "$PORT" ]; then
+            PORT=443
+          fi
+
+          if [ -z "$DOMAIN" ] || [ -z "$UUID" ]; then
+            echo "::error::Missing domain or UUID for generating client configuration."
+            exit 1
+          fi
+
+          export CLIENT_NAME="Less Vision (${DOMAIN})"
+          NAME_ENCODED=$(python - <<'PY'
+import os
+import urllib.parse
+
+print(urllib.parse.quote(os.environ["CLIENT_NAME"]))
+PY
+)
+
+          ALPN_ENCODED="h2%2Chttp%2F1.1"
+
+          SHADOWROCKET_URI="vless://${UUID}@${DOMAIN}:${PORT}?encryption=none&security=tls&type=tcp&flow=${FLOW}&sni=${DOMAIN}&alpn=${ALPN_ENCODED}#${NAME_ENCODED}"
+          CLASH_META_URI="vless://${UUID}@${DOMAIN}:${PORT}?encryption=none&security=tls&type=tcp&flow=${FLOW}&sni=${DOMAIN}&alpn=${ALPN_ENCODED}&fp=chrome#${NAME_ENCODED}"
+
+          CLASH_VERGE_BLOCK=$(cat <<EOF
+  - name: Less Vision (${DOMAIN})
+    type: vless
+    server: ${DOMAIN}
+    port: ${PORT}
+    uuid: ${UUID}
+    cipher: none
+    tls: true
+    network: tcp
+    flow: ${FLOW}
+    udp: true
+    servername: ${DOMAIN}
+    alpn:
+      - h2
+      - http/1.1
+EOF
+)
+
+          cat <<EOF
+============================================================
+Client Configuration Summary
+============================================================
+
+Shadowrocket (iOS)
+------------------
+${SHADOWROCKET_URI}
+
+Clash Meta (Android)
+--------------------
+${CLASH_META_URI}
+
+Clash Verge (macOS)
+-------------------
+${CLASH_VERGE_BLOCK}
+
+EOF


### PR DESCRIPTION
## Summary
- add a post-deploy step that prints Shadowrocket and Clash Meta connection strings
- include a ready-to-paste Clash Verge configuration block in the workflow output

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68ff4f1a23188322ac1e3c67c78852d9