### PR TITLE
Fix deploy workflow YAML syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,52 +153,42 @@ jobs:
           fi
 
           export CLIENT_NAME="Less Vision (${DOMAIN})"
-          NAME_ENCODED=$(python - <<'PY'
-import os
-import urllib.parse
-
-print(urllib.parse.quote(os.environ["CLIENT_NAME"]))
-PY
-)
+          NAME_ENCODED=$(python -c "import os, urllib.parse; print(urllib.parse.quote(os.environ['CLIENT_NAME']))")
 
           ALPN_ENCODED="h2%2Chttp%2F1.1"
 
           SHADOWROCKET_URI="vless://${UUID}@${DOMAIN}:${PORT}?encryption=none&security=tls&type=tcp&flow=${FLOW}&sni=${DOMAIN}&alpn=${ALPN_ENCODED}#${NAME_ENCODED}"
           CLASH_META_URI="vless://${UUID}@${DOMAIN}:${PORT}?encryption=none&security=tls&type=tcp&flow=${FLOW}&sni=${DOMAIN}&alpn=${ALPN_ENCODED}&fp=chrome#${NAME_ENCODED}"
 
-          CLASH_VERGE_BLOCK=$(cat <<EOF
-  - name: Less Vision (${DOMAIN})
-    type: vless
-    server: ${DOMAIN}
-    port: ${PORT}
-    uuid: ${UUID}
-    cipher: none
-    tls: true
-    network: tcp
-    flow: ${FLOW}
-    udp: true
-    servername: ${DOMAIN}
-    alpn:
-      - h2
-      - http/1.1
-EOF
-)
+          CLASH_VERGE_BLOCK=$(printf '%s\n' \
+            "- name: Less Vision (${DOMAIN})" \
+            "  type: vless" \
+            "  server: ${DOMAIN}" \
+            "  port: ${PORT}" \
+            "  uuid: ${UUID}" \
+            "  cipher: none" \
+            "  tls: true" \
+            "  network: tcp" \
+            "  flow: ${FLOW}" \
+            "  udp: true" \
+            "  servername: ${DOMAIN}" \
+            "  alpn:" \
+            "    - h2" \
+            "    - http/1.1")
 
-          cat <<EOF
-============================================================
-Client Configuration Summary
-============================================================
-
-Shadowrocket (iOS)
-------------------
-${SHADOWROCKET_URI}
-
-Clash Meta (Android)
---------------------
-${CLASH_META_URI}
-
-Clash Verge (macOS)
--------------------
-${CLASH_VERGE_BLOCK}
-
-EOF
+          printf '%s\n' \
+            "============================================================" \
+            "Client Configuration Summary" \
+            "============================================================" \
+            "" \
+            "Shadowrocket (iOS)" \
+            "------------------" \
+            "${SHADOWROCKET_URI}" \
+            "" \
+            "Clash Meta (Android)" \
+            "--------------------" \
+            "${CLASH_META_URI}" \
+            "" \
+            "Clash Verge (macOS)" \
+            "-------------------" \
+            "${CLASH_VERGE_BLOCK}"


### PR DESCRIPTION
## Summary
- replace the heredoc Python snippet with an inline python -c call so the workflow YAML stays valid
- render the client output blocks with printf calls to avoid unindented heredocs that break YAML parsing

## Testing
- yamllint .github/workflows/deploy.yml

------
https://chatgpt.com/codex/tasks/task_b_68ff513332c88322802aa3a79796a694