### PR TITLE
Add Terraform workflow with runner context fix

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,44 @@
+name: Terraform
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Terraform workspace to target"
+        required: true
+        default: example
+        type: choice
+        options:
+          - example
+
+permissions:
+  contents: read
+
+env:
+  TF_PLUGIN_CACHE_DIR: ${{ runner.temp }}/terraform-plugin-cache
+
+jobs:
+  plan:
+    name: Terraform plan
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: terraform/examples
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform init
+        run: terraform init -input=false
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform plan
+        run: terraform plan -input=false


### PR DESCRIPTION
## Summary
- add a Terraform GitHub Actions workflow that can be dispatched manually
- configure the plugin cache directory using the `${{ runner.temp }}` expression
- run standard Terraform init, validate, and plan steps against the example configuration

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68ff99fbaf30832283ab7e64cb7b8e5f