### PR TITLE
Switch to official xray-core container image

### DIFF
--- a/ansible/roles/docker_compose/defaults/main.yml
+++ b/ansible/roles/docker_compose/defaults/main.yml
@@ -6,5 +6,5 @@ xray_config_dir: "{{ project_root }}/xray"
 xray_domain: ""
 xray_inbound_port: 443
 xray_service_port: "{{ xray_inbound_port }}"
-xray_image: "teddysun/xray:latest"
+xray_image: "ghcr.io/xtls/xray-core:25.10.15"
 docker_compose_up: true

--- a/ansible/roles/docker_compose/templates/docker-compose.yml.j2
+++ b/ansible/roles/docker_compose/templates/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     container_name: xray
     restart: unless-stopped
     volumes:
-      - "{{ xray_config_dir }}:/etc/xray:ro"
+      - "{{ xray_config_dir }}:/usr/local/etc/xray:ro"
       - "{{ certificates_dir }}:/etc/ssl:ro"
     ports:
       - "{{ xray_inbound_port }}:{{ xray_service_port }}"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,7 +36,7 @@ Pass the following variables via `--extra-vars` or inventory:
 | `xray_log_level` | `warning` | Log level for Xray. |
 | `compose_project_directory` | `{{ project_root }}/compose` | Directory containing rendered Docker Compose assets. |
 | `xray_config_dir` | `{{ project_root }}/xray` | Directory where `config.json` is rendered. |
-| `xray_image` | `teddysun/xray:latest` | Docker image used for the Xray service. |
+| `xray_image` | `ghcr.io/xtls/xray-core:25.10.15` | Docker image used for the Xray service. |
 | `xray_container_certificate_path` | `/etc/ssl/live/{{ xray_domain }}/fullchain.pem` | Certificate path inside the container referenced by Xray config. |
 | `xray_container_private_key_path` | `/etc/ssl/live/{{ xray_domain }}/privkey.pem` | Private key path inside the container referenced by Xray config. |
 | `xray_alpn` | `["h2", "http/1.1"]` | ALPN values advertised to TLS clients. |
@@ -99,7 +99,7 @@ The [`CI`](../.github/workflows/ci.yml) workflow installs Ansible and runs `ansi
 ## Verification Steps
 1. Verify containers are running: `docker compose -f /opt/xray/compose/docker-compose.yml ps`.
 2. Test TLS certificate: `openssl s_client -connect example.com:443 -servername example.com`.
-3. Validate Xray config inside container: `docker compose -f /opt/xray/compose/docker-compose.yml exec xray xray -test -config /etc/xray/config.json`.
+3. Validate Xray config inside container: `docker compose -f /opt/xray/compose/docker-compose.yml exec xray xray -test -confdir /usr/local/etc/xray`.
 
 ## Troubleshooting
 - **Port 80 in use**: Stop any service occupying port 80 before requesting certificates.

--- a/specs.md
+++ b/specs.md
@@ -35,7 +35,7 @@ This document tracks the evolving specification for the automated deployment of 
 - Check mode skips the potentially destructive certificate issuance step while still reporting when issuance would have occurred.
 
 ## Docker Compose Considerations
-- Uses `teddysun/xray:latest` by default, relying on the image entrypoint to read `/etc/xray/config.json`.
+- Uses `ghcr.io/xtls/xray-core:25.10.15` by default, mounting the rendered configuration at `/usr/local/etc/xray` for the image's `-confdir` startup mode.
 - Volumes mount host config and certificate directories read-only.
 - Restart handler restarts the container when templates change, and `docker_compose_up` can disable runtime actions during dry runs.
 


### PR DESCRIPTION
## Summary
- update the default Xray container image to ghcr.io/xtls/xray-core:25.10.15
- mount the rendered configuration directory at /usr/local/etc/xray to align with the official image
- refresh documentation and specs to describe the new image and validation command

## Testing
- ⚠️ `ansible-playbook --syntax-check ansible/playbooks/site.yml` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_6900335282e88322b3cbc2c0aa7c7452