### PR TITLE
Adjust filesystem permissions for Xray config

### DIFF
--- a/ansible/roles/xray_config/tasks/main.yml
+++ b/ansible/roles/xray_config/tasks/main.yml
@@ -19,11 +19,11 @@
   ansible.builtin.file:
     path: "{{ xray_config_dir }}"
     state: directory
-    mode: "0750"
+    mode: "0755"
 
 - name: Render Xray configuration
   ansible.builtin.template:
     src: config.json.j2
     dest: "{{ xray_config_dir }}/config.json"
-    mode: "0640"
+    mode: "0644"
   notify: Restart xray container


### PR DESCRIPTION
## Summary
- relax the rendered Xray configuration directory and file permissions so the non-root official container image can read them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69003852a6088322acbc9ba4f8bdabf1