### PR TITLE
Add docker compose shutdown before redeploy

### DIFF
--- a/ansible/roles/docker_compose/defaults/main.yml
+++ b/ansible/roles/docker_compose/defaults/main.yml
@@ -13,3 +13,5 @@ xray_stability_check_count: 3
 xray_stability_check_delay: 30
 xray_failure_log_lines: 200
 docker_compose_up: true
+docker_compose_down_before_up: true
+docker_compose_remove_orphans: true

--- a/ansible/roles/docker_compose/handlers/main.yml
+++ b/ansible/roles/docker_compose/handlers/main.yml
@@ -7,6 +7,8 @@
   when:
     - docker_compose_up | bool
     - not ansible_check_mode
+  environment:
+    COMPOSE_FILE: "{{ compose_project_directory }}/docker-compose.yml"
   register: compose_restart
   changed_when: compose_restart.rc == 0
   failed_when: compose_restart.rc != 0

--- a/ansible/roles/docker_compose/tasks/main.yml
+++ b/ansible/roles/docker_compose/tasks/main.yml
@@ -11,6 +11,30 @@
     state: directory
     mode: "0750"
 
+- name: Check for existing docker compose project file
+  ansible.builtin.stat:
+    path: "{{ compose_project_directory }}/docker-compose.yml"
+  register: docker_compose_file
+
+- name: Stop existing docker compose project
+  ansible.builtin.command: >-
+    docker compose down{{ ' --remove-orphans' if docker_compose_remove_orphans | bool else '' }}
+  args:
+    chdir: "{{ compose_project_directory }}"
+  when:
+    - docker_compose_up | bool
+    - docker_compose_down_before_up | bool
+    - not ansible_check_mode
+    - docker_compose_file.stat.exists
+  environment:
+    COMPOSE_FILE: "{{ compose_project_directory }}/docker-compose.yml"
+  register: compose_down
+  changed_when: >-
+    compose_down.rc == 0 and (
+      (compose_down.stdout | default('') | trim | length) > 0 or
+      (compose_down.stderr | default('') | trim | length) > 0
+    )
+
 - name: Render Docker Compose file
   ansible.builtin.template:
     src: docker-compose.yml.j2
@@ -25,6 +49,8 @@
   when:
     - docker_compose_up | bool
     - not ansible_check_mode
+  environment:
+    COMPOSE_FILE: "{{ compose_project_directory }}/docker-compose.yml"
   register: compose_up
   changed_when: compose_up.rc == 0
 


### PR DESCRIPTION
## Summary
- add toggles for shutting down the compose project and removing orphans before redeploying
- stop any existing compose stack with the previous configuration before templating the new file
- ensure compose commands (including the restart handler) only target the rendered docker-compose.yml file

## Testing
- not run (ansible-playbook not available in container)


------
https://chatgpt.com/codex/tasks/task_b_690043aae1308322affff7a8dddeafbb