### PR TITLE
Define docker_compose_up default for xray cleanup role

### DIFF
--- a/ansible/roles/xray_cleanup/defaults/main.yml
+++ b/ansible/roles/xray_cleanup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Ensure xray_cleanup behaves consistently even when global variables
+# are not automatically loaded (e.g., when invoked via external playbooks).
+docker_compose_up: true


### PR DESCRIPTION
## Summary
- add a defaults file for the xray_cleanup role so docker_compose_up is always defined
- prevent undefined variable errors when the role runs in external playbooks such as lightsail-proxy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6907f2f490988322a63532ccf7b8bb03