### PR TITLE
Add daily reboot cron job at 04:00 CST

### DIFF
--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -6,6 +6,7 @@
     project_root: "/opt/xray"
   roles:
     - docker_prereqs
+    - system_maintenance
     - certificates
     - xray_cleanup
     - xray_deploy

--- a/ansible/roles/system_maintenance/tasks/main.yml
+++ b/ansible/roles/system_maintenance/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Ensure cron timezone is set to China Standard Time for reboot job
+  ansible.builtin.cron:
+    name: CRON_TZ
+    env: true
+    value: Asia/Shanghai
+
+- name: Schedule daily reboot at 04:00 China Standard Time
+  ansible.builtin.cron:
+    name: Daily reboot at 04:00 CST
+    minute: "0"
+    hour: "4"
+    job: "/usr/bin/systemctl reboot"
+    user: root
+    state: present


### PR DESCRIPTION
## Summary
- add a system maintenance role that sets the cron timezone to Asia/Shanghai and schedules a reboot
- include the new role in the primary deployment playbook so hosts reboot daily at 04:00 CST

## Testing
- `ansible-playbook -i inventory site.yml --syntax-check` *(fails: command not found - ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_b_69094d20eafc83229e94a22a9a8e6ed8